### PR TITLE
design polish items

### DIFF
--- a/src/components/DiagramFrame/HelpPanel.tsx
+++ b/src/components/DiagramFrame/HelpPanel.tsx
@@ -44,7 +44,7 @@ export const HelpPanel: React.FC<{
 }> = ({ 
  }) => {
   return (
-    <SettingsPanel width={`275px`} px="medium" py="large">
+    <SettingsPanel width={`375px`} px="medium" py="large">
       <SpaceVertical>
         <Heading fontSize="large">Diagram Help</Heading>
         <Label>Views</Label>
@@ -62,11 +62,11 @@ export const HelpPanel: React.FC<{
           zoomFactor={0.479}
           setZoomFactor={()=>{}}
           viewPosition={{
-            x: 58.98,
+            x: 100.98,
             y: -84.96,
             displayX: 0,
             displayY: 0,
-            clientWidth: 275,
+            clientWidth: 375,
             clientHeight: 150
           }}
           setViewPosition={()=>{}}
@@ -99,11 +99,11 @@ export const HelpPanel: React.FC<{
           zoomFactor={0.249}
           setZoomFactor={()=>{}}
           viewPosition={{
-            x: 16.12,
+            x: 56.12,
             y: -15.54,
             displayX: 0,
             displayY: 0,
-            clientWidth: 275,
+            clientWidth: 375,
             clientHeight: 190
           }}
           setViewPosition={()=>{}}

--- a/src/d3-utils/tables.ts
+++ b/src/d3-utils/tables.ts
@@ -113,7 +113,7 @@ export function createLookmlViewElement(
   .attr("d", getDatatypePath)
   .attr("class", "datatype-icon")
   .attr("transform", (d: DiagramField, i: number) => {
-    return `translate(0,${(DIAGRAM_FIELD_STROKE_WIDTH / 2)})scale(${DIAGRAM_ICON_SCALE})`
+    return `translate(2,${(DIAGRAM_FIELD_STROKE_WIDTH / 2) + 2})scale(${DIAGRAM_ICON_SCALE})`
   })
 
   // Add PK icon if needed
@@ -121,7 +121,7 @@ export function createLookmlViewElement(
   .attr("d", getPkPath)
   .attr("class", "pk-icon")
   .attr("transform", (d: DiagramField, i: number) => {
-    return `translate(${TABLE_WIDTH - (DIAGRAM_FIELD_STROKE_WIDTH * 3)}, ${DIAGRAM_FIELD_STROKE_WIDTH / 2})scale(${DIAGRAM_ICON_SCALE})`
+    return `translate(${TABLE_WIDTH - (DIAGRAM_FIELD_STROKE_WIDTH * 3)}, ${DIAGRAM_FIELD_STROKE_WIDTH / 2 + 2})scale(${DIAGRAM_ICON_SCALE})`
   })
 
   // Label table elements
@@ -129,14 +129,14 @@ export function createLookmlViewElement(
   .attr("transform", (d: DiagramField, i: number) => {
     return `translate(${i === 0 ? 5 : 25}, ${(DIAGRAM_FIELD_STROKE_WIDTH / 2)})`
   })
-  .attr("dy", "0.8em")
+  .attr("dy", "0.9em")
   .text((d: DiagramField) => getLabel(d));
 
   // Add dividers
   tableRow.append('line')
-  .attr('x1', 0)
+  .attr('x1', 0 - (DIAGRAM_FIELD_STROKE_WIDTH/2))
   .attr('y1', TABLE_ROW_HEIGHT + 3)
-  .attr('x2', TABLE_WIDTH)
+  .attr('x2', TABLE_WIDTH + (DIAGRAM_FIELD_STROKE_WIDTH/2))
   .attr('y2', TABLE_ROW_HEIGHT + 3)
   .attr('class', (d: DiagramField, i: number) => {
     return (i === 0 || i === (tableData.length - 1)) || "row-divider"


### PR DESCRIPTION
- Fixes left padding on field data type icon
- Centers view header and field row text
- row dividers extend 100% w
- help section size increase

![Screenshot from 2021-03-30 23-23-06](https://user-images.githubusercontent.com/56001784/113100110-cd9f3700-91af-11eb-91d3-f4e4e7f2a86b.png)
![Screenshot from 2021-03-30 23-31-03](https://user-images.githubusercontent.com/56001784/113100293-0fc87880-91b0-11eb-84f2-ec4e82eb902c.png)
