### PR TITLE
adds preparer funcs and docstrings

### DIFF
--- a/src/components/DiagramFrame/DiagramFrame.tsx
+++ b/src/components/DiagramFrame/DiagramFrame.tsx
@@ -104,19 +104,19 @@ export const DiagramFrame: React.FC<DiagramFrameProps> = ({
 
   const onlyDiagramSelected = () => { return showNoAside && !showViewOptions && !showSettings && !showHelp ? true : undefined }
 
-  let modelDetails = prepareModelDropdown(unfilteredModels)
+  const modelDetails = prepareModelDropdown(unfilteredModels)
 
   let currentExplore: ILookmlModelExplore = modelDetail?.explores.filter((d: ILookmlModelExplore)=>{
     return d.name === pathExploreName
   })[0]
 
-  let exploreList: ExploreDropdown[] = prepareExploreList(currentModel)
+  const exploreList: ExploreDropdown[] = prepareExploreList(currentModel)
 
-  let currentDimensions: DiagrammedModel = dimensions?.filter((d: DiagrammedModel)=>{
+  const currentDimensions: DiagrammedModel = dimensions?.filter((d: DiagrammedModel)=>{
     return d.exploreName === pathExploreName
   })[0]
 
-  let currentDiagramMetadata: DiagramMetadata = currentDimensions?.diagramDict
+  const currentDiagramMetadata: DiagramMetadata = currentDimensions?.diagramDict
 
   let defaultViews: VisibleViewLookup = {}
   Object.keys(viewVisible).length === 0 && currentExplore && currentDiagramMetadata && Object.keys(currentDiagramMetadata.tableData)

--- a/src/components/DiagramFrame/DiagramFrame.tsx
+++ b/src/components/DiagramFrame/DiagramFrame.tsx
@@ -48,10 +48,10 @@ import {
   OVERRIDE_KEY,
   OVERRIDE_KEY_SUBTLE
 } from '../../utils/constants'
-import { ILookmlModel, ILookmlModelExplore, IGitBranch } from "@looker/sdk/lib/sdk/4.0/models"
+import { ILookmlModelExplore } from "@looker/sdk/lib/sdk/4.0/models"
 import {DiagramFrameProps, ExploreDropdown} from "./types"
 import {Rail, Stage} from "./components"
-import {getBranchOptions} from "./utils"
+import {getBranchOptions, prepareModelDropdown, prepareExploreList} from "./utils"
 
 export const DiagramFrame: React.FC<DiagramFrameProps> = ({
   unfilteredModels,
@@ -104,25 +104,13 @@ export const DiagramFrame: React.FC<DiagramFrameProps> = ({
 
   const onlyDiagramSelected = () => { return showNoAside && !showViewOptions && !showSettings && !showHelp ? true : undefined }
 
-  let modelDetails = unfilteredModels ? unfilteredModels.filter((d: ILookmlModel)=>{ 
-    return d.explores.length >= 1
-  }).map((d: ILookmlModel)=>{
-    return {
-      value: d.name,
-      label: d.label
-    }
-  }).sort((a: SelectOptionProps, b: SelectOptionProps) => a.label < b.label ? -1 : 1) : []
+  let modelDetails = prepareModelDropdown(unfilteredModels)
 
   let currentExplore: ILookmlModelExplore = modelDetail?.explores.filter((d: ILookmlModelExplore)=>{
     return d.name === pathExploreName
   })[0]
 
-  let exploreList: ExploreDropdown[] = currentModel?.explores.map((d: ILookmlModelExplore)=>{
-    return {
-      value: d.name,
-      label: d.label
-    }
-  }).sort((a: ExploreDropdown, b: ExploreDropdown) => a.label < b.label ? -1 : 1)
+  let exploreList: ExploreDropdown[] = prepareExploreList(currentModel)
 
   let currentDimensions: DiagrammedModel = dimensions?.filter((d: DiagrammedModel)=>{
     return d.exploreName === pathExploreName

--- a/src/components/DiagramFrame/DiagramSettings.tsx
+++ b/src/components/DiagramFrame/DiagramSettings.tsx
@@ -39,7 +39,7 @@ import { useHistory } from "react-router"
 import { ExtensionContext } from "@looker/extension-sdk-react"
 import { ExploreDropdown, DiagramSettingsProps } from "./types"
 import {ExploreList, ExploreListitem, ExploreButton, SettingsPanel} from "./components"
-import { getExploreListItemBackground } from "./utils"
+import { getExploreListItemBackgroundColor } from "./utils"
 
 export const DiagramSettings: React.FC<DiagramSettingsProps> = ({ 
   modelDetails,
@@ -96,7 +96,7 @@ export const DiagramSettings: React.FC<DiagramSettingsProps> = ({
               <ExploreList>
                 {exploreList && exploreList.map((explore: ExploreDropdown, index: number) => {
                   return (
-                    <ExploreListitem key={`explore-${index}`} style={{backgroundColor: getExploreListItemBackground(explore.value, currentExplore, diagramExplore)}}>
+                    <ExploreListitem key={`explore-${index}`} style={{backgroundColor: getExploreListItemBackgroundColor(explore.value, currentExplore, diagramExplore)}}>
                       <ExploreButton
                         onClick={() => {
                           selectionInfo.lookmlElement === "explore" || setSelectionInfo({})

--- a/src/components/DiagramFrame/DiagramSettings.tsx
+++ b/src/components/DiagramFrame/DiagramSettings.tsx
@@ -39,7 +39,7 @@ import { useHistory } from "react-router"
 import { ExtensionContext } from "@looker/extension-sdk-react"
 import { ExploreDropdown, DiagramSettingsProps } from "./types"
 import {ExploreList, ExploreListitem, ExploreButton, SettingsPanel} from "./components"
-import { buttonShade } from "./utils"
+import { getExploreListItemBackground } from "./utils"
 
 export const DiagramSettings: React.FC<DiagramSettingsProps> = ({ 
   modelDetails,
@@ -96,7 +96,7 @@ export const DiagramSettings: React.FC<DiagramSettingsProps> = ({
               <ExploreList>
                 {exploreList && exploreList.map((explore: ExploreDropdown, index: number) => {
                   return (
-                    <ExploreListitem key={`explore-${index}`} style={{backgroundColor: buttonShade(explore.value, currentExplore, diagramExplore)}}>
+                    <ExploreListitem key={`explore-${index}`} style={{backgroundColor: getExploreListItemBackground(explore.value, currentExplore, diagramExplore)}}>
                       <ExploreButton
                         onClick={() => {
                           selectionInfo.lookmlElement === "explore" || setSelectionInfo({})

--- a/src/components/DiagramFrame/ViewOptions.tsx
+++ b/src/components/DiagramFrame/ViewOptions.tsx
@@ -42,7 +42,7 @@ import {
 } from "@looker/components"
 import {ViewOptionsProps} from "./types"
 import {ViewList, ViewListItem, ViewButton, SettingsPanel} from "./components"
-import {viewDisabled} from "./utils"
+import {getViewListItemColor} from "./utils"
 
 export const ViewOptions: React.FC<ViewOptionsProps> = ({ 
   displayFieldType,
@@ -119,11 +119,11 @@ export const ViewOptions: React.FC<ViewOptionsProps> = ({
               </FlexItem>
               <FlexItem>
                 <ViewList>
-                  {viewVisible && Object.keys(viewVisible).map((item: string, index) => {
+                  {viewVisible && Object.keys(viewVisible).map((item: string, index: number) => {
                     return (
-                      <ViewListItem key={`view-${index}`} style={{color: viewDisabled(viewVisible[item])}}>
+                      <ViewListItem key={`view-${index}`} style={{color: getViewListItemColor(viewVisible[item])}}>
                         <ViewButton
-                              onClick={(e: any) => {
+                              onClick={() => {
                                 let newViews: any = {}
                                 Object.assign(newViews, viewVisible)
                                 newViews[item] = !viewVisible[item]

--- a/src/components/DiagramFrame/utils.ts
+++ b/src/components/DiagramFrame/utils.ts
@@ -4,14 +4,14 @@ import { OVERRIDE_KEY_SUBTLE, DIAGRAM_IGNORED_MODELS } from "../../utils/constan
 import { ExploreDropdown } from "./types"
 
 /**
- * styles the view list according to visibility status
+ * get the color of a view list item according to its visibility status
  * @param disabled - whether or not the current view is disabled
  */
-export function viewDisabled(disabled: boolean) {
-  if (!disabled) {
-    return theme.colors.text1
+export function getViewListItemColor(disabled: boolean) {
+  if (disabled) {
+    return undefined
   }
-  return undefined
+  return theme.colors.text1
 }
 
 /**
@@ -21,33 +21,28 @@ export function viewDisabled(disabled: boolean) {
  */
 export const getBranchOptions = (gitBranch: IGitBranch, gitBranches: IGitBranch[]) => {
   return gitBranches.map((branch: IGitBranch) => {
-    let opt: SelectOptionProps = {
-      value: undefined,
-      label: undefined,
-    }
     if (gitBranch.name === branch.name) {
-      opt = {
+      return {
         value: branch.name, 
         label: branch.name, 
         icon: "GitBranch"
       }
     } else {
-      opt = {
+      return {
         value: branch.name, 
         label: branch.name, 
       }
     }
-    return opt
   })
 }
 
 /**
- * determines whether a Select an Explore list item should be shaded
+ * gets the background color for each ExploreListItem
  * @param exploreNameSel - name of the explore list item
  * @param currentExplore - current url explore obj
  * @param diagramExplore - current diagrammed explore obj
  */
-export function buttonShade(exploreNameSel: string, currentExplore: ILookmlModelExplore, diagramExplore: string) {
+export function getExploreListItemBackground(exploreNameSel: string, currentExplore: ILookmlModelExplore, diagramExplore: string) {
   if (currentExplore && currentExplore.name === exploreNameSel) {
     return OVERRIDE_KEY_SUBTLE
   }
@@ -61,18 +56,15 @@ export function buttonShade(exploreNameSel: string, currentExplore: ILookmlModel
  * Prepares a list of diagrammable models for the Choose a Model dropdown
  * @param unfilteredModels - the unprepared list of models
  */
-export function prepareModelDropdown(unfilteredModels: ILookmlModel[]) {
-  if (unfilteredModels) {
-    return unfilteredModels.filter((d: ILookmlModel)=>{ 
-      return d.explores.length >= 1 && !DIAGRAM_IGNORED_MODELS.includes(d.name)
-    }).map((d: ILookmlModel)=>{
-      return {
-        value: d.name,
-        label: d.label
-      }
-    }).sort((a: SelectOptionProps, b: SelectOptionProps) => a.label < b.label ? -1 : 1)
-  }
-  return []
+export function prepareModelDropdown(unfilteredModels: ILookmlModel[] = []) {
+  return unfilteredModels.filter((d: ILookmlModel)=>{ 
+    return d.explores.length >= 1 && !DIAGRAM_IGNORED_MODELS.includes(d.name)
+  }).map((d: ILookmlModel)=>{
+    return {
+      value: d.name,
+      label: d.label
+    }
+  }).sort((a: SelectOptionProps, b: SelectOptionProps) => a.label < b.label ? -1 : 1)
 }
 
 /**
@@ -80,13 +72,10 @@ export function prepareModelDropdown(unfilteredModels: ILookmlModel[]) {
  * @param unfilteredModels - the unprepared list of models
  */
 export function prepareExploreList(currentModel: ILookmlModel) {
-  if (currentModel) {
-    return currentModel.explores.map((d: ILookmlModelExplore)=>{
-      return {
-        value: d.name,
-        label: d.label
-      }
-    }).sort((a: ExploreDropdown, b: ExploreDropdown) => a.label < b.label ? -1 : 1)
-  }
-  return []
+  return currentModel?.explores.map((d: ILookmlModelExplore)=>{
+    return {
+      value: d.name,
+      label: d.label
+    }
+  }).sort((a: ExploreDropdown, b: ExploreDropdown) => a.label < b.label ? -1 : 1)
 }

--- a/src/components/DiagramFrame/utils.ts
+++ b/src/components/DiagramFrame/utils.ts
@@ -21,17 +21,13 @@ export function getViewListItemColor(disabled: boolean) {
  */
 export const getBranchOptions = (gitBranch: IGitBranch, gitBranches: IGitBranch[]) => {
   return gitBranches.map((branch: IGitBranch) => {
-    if (gitBranch.name === branch.name) {
-      return {
-        value: branch.name, 
-        label: branch.name, 
-        icon: "GitBranch"
-      }
-    } else {
-      return {
-        value: branch.name, 
-        label: branch.name, 
-      }
+    return gitBranch.name === branch.name ? {
+      value: branch.name, 
+      label: branch.name, 
+      icon: "GitBranch"
+    } : {
+      value: branch.name, 
+      label: branch.name, 
     }
   })
 }
@@ -42,7 +38,7 @@ export const getBranchOptions = (gitBranch: IGitBranch, gitBranches: IGitBranch[
  * @param currentExplore - current url explore obj
  * @param diagramExplore - current diagrammed explore obj
  */
-export function getExploreListItemBackground(exploreNameSel: string, currentExplore: ILookmlModelExplore, diagramExplore: string) {
+export function getExploreListItemBackgroundColor(exploreNameSel: string, currentExplore: ILookmlModelExplore, diagramExplore: string) {
   if (currentExplore && currentExplore.name === exploreNameSel) {
     return OVERRIDE_KEY_SUBTLE
   }
@@ -53,7 +49,7 @@ export function getExploreListItemBackground(exploreNameSel: string, currentExpl
 }
 
 /**
- * Prepares a list of diagrammable models for the Choose a Model dropdown
+ * Prepares a list of diagrammable models for the 'Choose a Model' dropdown
  * @param unfilteredModels - the unprepared list of models
  */
 export function prepareModelDropdown(unfilteredModels: ILookmlModel[] = []) {
@@ -68,7 +64,7 @@ export function prepareModelDropdown(unfilteredModels: ILookmlModel[] = []) {
 }
 
 /**
- * Prepares a list of diagrammable explores for the Select an Explore list
+ * Prepares a list of diagrammable explores for the 'Select an Explore' list
  * @param unfilteredModels - the unprepared list of models
  */
 export function prepareExploreList(currentModel: ILookmlModel) {

--- a/src/components/DiagramFrame/utils.ts
+++ b/src/components/DiagramFrame/utils.ts
@@ -1,7 +1,12 @@
-import { IGitBranch, ILookmlModelExplore } from "@looker/sdk/lib/sdk/3.1/models"
+import { IGitBranch, ILookmlModel, ILookmlModelExplore } from "@looker/sdk/lib/sdk/3.1/models"
 import { SelectOptionProps, theme } from "@looker/components"
-import { OVERRIDE_KEY_SUBTLE } from "../../utils/constants"
+import { OVERRIDE_KEY_SUBTLE, DIAGRAM_IGNORED_MODELS } from "../../utils/constants"
+import { ExploreDropdown } from "./types"
 
+/**
+ * styles the view list according to visibility status
+ * @param disabled - whether or not the current view is disabled
+ */
 export function viewDisabled(disabled: boolean) {
   if (!disabled) {
     return theme.colors.text1
@@ -9,6 +14,11 @@ export function viewDisabled(disabled: boolean) {
   return undefined
 }
 
+/**
+ * prepares the Git Branch dropdown data
+ * @param gitBranch - currently selected branch obj
+ * @param gitBranches - list of available branch objs
+ */
 export const getBranchOptions = (gitBranch: IGitBranch, gitBranches: IGitBranch[]) => {
   return gitBranches.map((branch: IGitBranch) => {
     let opt: SelectOptionProps = {
@@ -31,6 +41,12 @@ export const getBranchOptions = (gitBranch: IGitBranch, gitBranches: IGitBranch[
   })
 }
 
+/**
+ * determines whether a Select an Explore list item should be shaded
+ * @param exploreNameSel - name of the explore list item
+ * @param currentExplore - current url explore obj
+ * @param diagramExplore - current diagrammed explore obj
+ */
 export function buttonShade(exploreNameSel: string, currentExplore: ILookmlModelExplore, diagramExplore: string) {
   if (currentExplore && currentExplore.name === exploreNameSel) {
     return OVERRIDE_KEY_SUBTLE
@@ -39,4 +55,38 @@ export function buttonShade(exploreNameSel: string, currentExplore: ILookmlModel
     return OVERRIDE_KEY_SUBTLE
   }
   return undefined
+}
+
+/**
+ * Prepares a list of diagrammable models for the Choose a Model dropdown
+ * @param unfilteredModels - the unprepared list of models
+ */
+export function prepareModelDropdown(unfilteredModels: ILookmlModel[]) {
+  if (unfilteredModels) {
+    return unfilteredModels.filter((d: ILookmlModel)=>{ 
+      return d.explores.length >= 1 && !DIAGRAM_IGNORED_MODELS.includes(d.name)
+    }).map((d: ILookmlModel)=>{
+      return {
+        value: d.name,
+        label: d.label
+      }
+    }).sort((a: SelectOptionProps, b: SelectOptionProps) => a.label < b.label ? -1 : 1)
+  }
+  return []
+}
+
+/**
+ * Prepares a list of diagrammable explores for the Select an Explore list
+ * @param unfilteredModels - the unprepared list of models
+ */
+export function prepareExploreList(currentModel: ILookmlModel) {
+  if (currentModel) {
+    return currentModel.explores.map((d: ILookmlModelExplore)=>{
+      return {
+        value: d.name,
+        label: d.label
+      }
+    }).sort((a: ExploreDropdown, b: ExploreDropdown) => a.label < b.label ? -1 : 1)
+  }
+  return []
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -66,3 +66,5 @@ export const DIAGRAM_SHADOW_RADIUS = 4
 export const DIAGRAM_SHADOW_ALPHA = 7
 
 export const CAP_RADIUS = 7
+
+export const DIAGRAM_IGNORED_MODELS = ['system__activity']


### PR DESCRIPTION
As part of general refactoring, this PR adds dropdown preparer functions and docstrings to DiagramFrame utils. 

Also prevents the System Activity model from being shown in the "Choose a Model" dropdown, as the partial api response is not diagrammable and developers need helltool access to see the application's model source code.

https://looker.atlassian.net/browse/EMBED-1674
