### PR TITLE
fix: finds real base view if not explore name

### DIFF
--- a/src/components/DiagramFrame/DiagramCanvas/Diagram.tsx
+++ b/src/components/DiagramFrame/DiagramCanvas/Diagram.tsx
@@ -72,6 +72,7 @@ export const Diagram: React.FC<DiagramProps> = memo(({
       .on("click", () => {
         setSelectionInfo({})
       })
+      .attr('fill', type === "minimap" ? 'transparent' : 'url(#dotsPattern)');
 
       // Add global svg defs
       let zoom = addZoom(svg, zoomFactor, setZoomFactor, viewPosition, setViewPosition, type);

--- a/src/components/DiagramFrame/DiagramCanvas/components/DiagramSpace.tsx
+++ b/src/components/DiagramFrame/DiagramCanvas/components/DiagramSpace.tsx
@@ -65,10 +65,6 @@ width: 100%;
 height: 100%;
 user-select: none;
 
-.clickable-background {
-  fill: transparent;
-}
-
 rect.table-background {
   stroke: ${TABLE_BACKGROUND_COLOR};
   stroke-width: 10;

--- a/src/components/DiagramFrame/DiagramCanvas/components/DiagramSpace.tsx
+++ b/src/components/DiagramFrame/DiagramCanvas/components/DiagramSpace.tsx
@@ -219,14 +219,13 @@ g.join-path-selected > marker > path {
 }
 
 g.join-path-selected > text.join-path-icon-label {
-  fill: ${DIAGRAM_TEXT_COLOR};
-  font-size: xx-small;
-  font-family: monospace;
-  text-anchor: middle;
+  fill: ${theme.colors.text5};
+  font-size: medium;
+  font-weight: ${theme.fontWeights.medium}
 }
 
 g.join-path-selected > rect.join-path-icon-background {
-  fill: ${DIAGRAM_BACKGROUND_COLOR};
+  fill: ${DIAGRAM_FIELD_COLOR};
 }
 
 g.join-path-selected > path.join-path-icon-right,

--- a/src/components/DiagramFrame/DiagramCanvas/components/DiagramSpace.tsx
+++ b/src/components/DiagramFrame/DiagramCanvas/components/DiagramSpace.tsx
@@ -161,6 +161,7 @@ g.table-row:not(.table-row-selected):not(.minimap-table-row):not(.help-table-row
   fill: ${DIAGRAM_HOVER_COLOR};
 }
 
+g.table-row.table-row-base-view:not(.table-row-selected):not(.minimap-table-row):not(.help-table-row):hover > rect,
 g.table-row.table-row-base-view:not(.table-row-selected):not(.minimap-table-row):not(.help-table-row):hover > path.table-row {
   fill: ${DIAGRAM_BASE_VIEW_HOVER_COLOR};
   stroke: ${DIAGRAM_BASE_VIEW_HOVER_COLOR};

--- a/src/components/DiagramFrame/DiagramCanvas/components/Layout.tsx
+++ b/src/components/DiagramFrame/DiagramCanvas/components/Layout.tsx
@@ -86,4 +86,9 @@ height: auto;
 right: 20px;
 top: 20px;
 position: absolute;
+border-width: 3px;
+border-color: white;
+:hover {
+  border-color: white;
+}
 `

--- a/src/components/DiagramFrame/FramePanels/HelpPanel.tsx
+++ b/src/components/DiagramFrame/FramePanels/HelpPanel.tsx
@@ -64,11 +64,11 @@ export const HelpPanel: React.FC<{
           setZoomFactor={()=>{}}
           viewPosition={{
             x: 55.98,
-            y: -84.96,
+            y: -86,
             displayX: 0,
             displayY: 0,
             clientWidth: 375,
-            clientHeight: 150
+            clientHeight: 155
           }}
           setViewPosition={()=>{}}
         />
@@ -100,7 +100,7 @@ export const HelpPanel: React.FC<{
           zoomFactor={0.249}
           setZoomFactor={()=>{}}
           viewPosition={{
-            x: 20.12,
+            x: 10.12,
             y: -15.54,
             displayX: 0,
             displayY: 0,

--- a/src/d3-utils/join-icon.ts
+++ b/src/d3-utils/join-icon.ts
@@ -34,7 +34,7 @@ export function makeJoinIcon(join: any, iconWidth: number, pillWidth: number, lX
   .attr("width", pillWidth)
   .attr("height", 36)
   .attr("transform", `translate(${lX + 2.5}, ${lY + 5})`)
-  .style("filter", "url(#pill-shadow)")
+  .style("filter", "url(#drop-shadow)")
   .style("opacity", 0.3)
 
   join.append("rect")

--- a/src/d3-utils/join-icon.ts
+++ b/src/d3-utils/join-icon.ts
@@ -24,24 +24,27 @@
 
  */
 
-export function makeJoinIcon(join: any, iconOffset: number, lX: number, lY: number, cX: number, isCross: boolean, leftFill: number, rightFill: number, joinTypeLabel: string) {
-  join.append("rect")
-  .attr("fill", "none")
-  .attr("class", "join-path-icon-background")
-  .style("rx", 10)
-  .style("ry", 10)
-  .attr("width", (iconOffset * 2) - 5)
-  .attr("height", (iconOffset * 2))
-  .attr("transform", `translate(${lX + 2.5}, ${lY + 5})`)
+export function makeJoinIcon(join: any, iconWidth: number, pillWidth: number, lX: number, lY: number, cX: number, isCross: boolean, leftFill: number, rightFill: number, joinTypeLabel: string) {
 
   join.append("rect")
   .attr("fill", "none")
   .attr("class", "join-path-icon-background")
-  .style("rx", 10)
-  .style("ry", 10)
-  .attr("width", (iconOffset * 2) + 15)
-  .attr("height", 18)
-  .attr("transform", `translate(${lX - 7.5}, ${lY + 35})`)
+  .style("rx", 15)
+  .style("ry", 15)
+  .attr("width", pillWidth)
+  .attr("height", 36)
+  .attr("transform", `translate(${lX + 2.5}, ${lY + 5})`)
+  .style("filter", "url(#pill-shadow)")
+  .style("opacity", 0.3)
+
+  join.append("rect")
+  .attr("fill", "none")
+  .attr("class", "join-path-icon-background")
+  .style("rx", 15)
+  .style("ry", 15)
+  .attr("width", pillWidth)
+  .attr("height", 36)
+  .attr("transform", `translate(${lX + 2.5}, ${lY + 5})`)
 
   isCross || join.append("path")
   .attr("d", "M23.6468 14.9375C17.7708 16.8958 14.834 26.6875 23.6468 32.5625C32.46 25.7083 28.5434 16.8958 23.6468 14.9375Z")
@@ -143,5 +146,5 @@ export function makeJoinIcon(join: any, iconOffset: number, lX: number, lY: numb
   .attr("class", "join-path-icon-label")
   .attr("fill", "none")
   .text(joinTypeLabel)
-  .attr("transform", `translate(${cX}, ${lY + 48})`);
+  .attr("transform", `translate(${lX + iconWidth - 2}, ${lY + 29})`);
 }

--- a/src/d3-utils/styles.ts
+++ b/src/d3-utils/styles.ts
@@ -66,8 +66,6 @@ export function addFilter(svg: any) {
   // store result in offsetBlur
   filter.append("feOffset")
   .attr("in", "blur")
-  .attr("dx", DIAGRAM_SHADOW_RADIUS)
-  .attr("dy", DIAGRAM_SHADOW_RADIUS)
   .attr("result", "offsetBlur");
   // overlay original SourceGraphic over translated blurred opacity by using
   // feMerge filter. Order of specifying inputs is important!
@@ -77,32 +75,23 @@ export function addFilter(svg: any) {
   feMerge.append("feMergeNode")
   .attr("in", "SourceGraphic");
 
-  var filter = defs.append("filter")
-  .attr("id", "pill-shadow")
-  .attr("width", "150%")
-  .attr("y", "-40%")
-  .attr("height", "200%");
-
-  filter.append("feGaussianBlur")
-  .attr("in", "SourceAlpha")
-  .attr("stdDeviation", DIAGRAM_SHADOW_ALPHA)
-  .attr("result", "blur");
-
-  filter.append("feOffset")
-  .attr("in", "blur")
-  .attr("result", "offsetBlur");
-
-  filter.append("feFlood")
-  .attr("in", "offsetBlur")
-  .attr("flood-color", theme.colors.background)
-  .attr("flood-opacity", "0.2")
-  .attr("result", "offsetColor");
-
-  var feMerge = filter.append("feMerge");
-  feMerge.append("feMergeNode")
-  .attr("in", "offsetBlur")
-  feMerge.append("feMergeNode")
-  .attr("in", "SourceGraphic");
+  var pattern = svg
+  .append('defs')
+  .append('pattern')
+  .attr('id', 'dotsPattern')
+  .attr('patternUnits', 'userSpaceOnUse')
+  .attr('width', 30)
+  .attr('height', 30);
+  pattern.append('circle')
+  .attr('cx', 15)
+  .attr('cy', 15)
+  .attr('r', 2)
+  .style('fill', "#e7eaec");
+  pattern.append('circle')
+  .attr('cx', 35)
+  .attr('cy', 35)
+  .attr('r', 2)
+  .style('fill', "#e7eaec");
 }
 
 export function getTranslation(transform: string) {

--- a/src/d3-utils/styles.ts
+++ b/src/d3-utils/styles.ts
@@ -23,7 +23,7 @@
  SOFTWARE.
 
  */
-
+import { theme } from "@looker/components"
 import { 
   MAX_TEXT_LENGTH, 
   DIAGRAM_SHADOW_RADIUS, 
@@ -53,6 +53,7 @@ export function addFilter(svg: any) {
   var filter = defs.append("filter")
   .attr("id", "drop-shadow")
   .attr("width", "150%")
+  .attr("y", "-40%")
   .attr("height", "200%");
   // SourceAlpha refers to opacity of graphic that this filter will be applied to
   // convolve that with a Gaussian with standard deviation 3 and store result
@@ -70,6 +71,33 @@ export function addFilter(svg: any) {
   .attr("result", "offsetBlur");
   // overlay original SourceGraphic over translated blurred opacity by using
   // feMerge filter. Order of specifying inputs is important!
+  var feMerge = filter.append("feMerge");
+  feMerge.append("feMergeNode")
+  .attr("in", "offsetBlur")
+  feMerge.append("feMergeNode")
+  .attr("in", "SourceGraphic");
+
+  var filter = defs.append("filter")
+  .attr("id", "pill-shadow")
+  .attr("width", "150%")
+  .attr("y", "-40%")
+  .attr("height", "200%");
+
+  filter.append("feGaussianBlur")
+  .attr("in", "SourceAlpha")
+  .attr("stdDeviation", DIAGRAM_SHADOW_ALPHA)
+  .attr("result", "blur");
+
+  filter.append("feOffset")
+  .attr("in", "blur")
+  .attr("result", "offsetBlur");
+
+  filter.append("feFlood")
+  .attr("in", "offsetBlur")
+  .attr("flood-color", theme.colors.background)
+  .attr("flood-opacity", "0.2")
+  .attr("result", "offsetColor");
+
   var feMerge = filter.append("feMerge");
   feMerge.append("feMergeNode")
   .attr("in", "offsetBlur")

--- a/src/d3-utils/tables.ts
+++ b/src/d3-utils/tables.ts
@@ -23,6 +23,7 @@
  SOFTWARE.
 
  */
+import {theme} from "@looker/components"
 import { 
   TABLE_WIDTH, 
   TABLE_ROW_HEIGHT, 
@@ -67,6 +68,19 @@ export function createLookmlViewElement(
   .attr("ry", CAP_RADIUS)
   .attr("width", TABLE_WIDTH)
   .attr("height", (tableData.length*(TABLE_ROW_HEIGHT+(DIAGRAM_FIELD_STROKE_WIDTH-1))-CAP_RADIUS))
+  .style("filter", "url(#drop-shadow)")
+  .style("opacity", 0.3)
+
+  type === "minimap" && table.append("rect")
+  .attr("x", header.diagramX)
+  .attr("y", header.diagramY)
+  .attr("rx", CAP_RADIUS)
+  .attr("ry", CAP_RADIUS)
+  .attr("width", TABLE_WIDTH)
+  .attr("height", (tableData.length*(TABLE_ROW_HEIGHT+(DIAGRAM_FIELD_STROKE_WIDTH-1))-CAP_RADIUS))
+  .style("stroke", theme.colors.text)
+  .style("stroke-width", "10px")
+  .style("fill", "transparent")
   
   let tableRow = table.selectAll(".table-row-"+header.view)
   .data(tableData)

--- a/src/utils/LookmlDiagrammer/diagrammer.ts
+++ b/src/utils/LookmlDiagrammer/diagrammer.ts
@@ -82,6 +82,7 @@ export function generateExploreDiagram(explore: ILookmlModelExplore, hiddenToggl
   const exploreJoins = explore.joins
   const fields = getFields(exploreFields)
   const views = getViews(exploreFields, exploreJoins, explore.name)
+  let baseViewName = ""
 
   // diagrammable metadata for a given explore
   // the structure is well suited for d3 and SVG
@@ -104,12 +105,16 @@ export function generateExploreDiagram(explore: ILookmlModelExplore, hiddenToggl
       return e.view === viewName && e.category === "dimension"
     }).length
 
+    if (explore.name === viewName || explore.sets[0].name === viewName) {
+      baseViewName = viewName
+    }
+
     // add initial table data to the diagram dict
     diagramDict.tableData[viewName] = [{
       category: "view", 
       view: viewName, 
       name: viewName, 
-      base: (explore.name === viewName || explore.view_name === viewName), 
+      base: viewName === baseViewName, 
       diagramX: 0, 
       diagramY: 0, 
       fieldTypeIndex: 0
@@ -161,7 +166,7 @@ export function generateExploreDiagram(explore: ILookmlModelExplore, hiddenToggl
     return joinPath
   })
 
-  // General order tables would be arranged in, if no joins and no base view
+  // General order tables would be arranged in, if no base view
   const joinCount = countJoins(diagramDict)
   let buildOrder = views.sort((a: string, b: string)=>{
     return joinCount[a] > joinCount[b] ? -1 : 1;
@@ -169,9 +174,9 @@ export function generateExploreDiagram(explore: ILookmlModelExplore, hiddenToggl
 
   const diagrammer = new LookmlDiagrammer(diagramDict, buildOrder, explore)
   
-  const baseViewName = diagramDict.tableData[explore.name] ? explore.name : buildOrder[0]
+  const seedName = baseViewName !== "" ? baseViewName : buildOrder[0]
 
-  Object.assign(diagramDict, diagrammer.getDiagram(baseViewName))
+  Object.assign(diagramDict, diagrammer.getDiagram(seedName))
 
   return diagramDict
 }

--- a/src/utils/LookmlDiagrammer/utils.ts
+++ b/src/utils/LookmlDiagrammer/utils.ts
@@ -66,7 +66,6 @@
        }
      })
    })
-   !views.includes(exploreName) && views.push(exploreName)
    return views.filter(onlyUnique).filter(onlyStrings)
  }
  


### PR DESCRIPTION
Sometimes the base view is not the explore name. This happens most frequently when using the "from:" parameter,
https://docs.looker.com/reference/explore-params/from-for-explore
But can also happen after object extension such as for marketplace models. 

This changes the resolution from adding a properly named but empty table to using the first table in the explore's "sets" array, which after testing is consistent with desired functionality. 
Before:
![image](https://user-images.githubusercontent.com/56001784/116013094-290fe980-a5e3-11eb-8f88-4e67888ea6b7.png)

After:
![image](https://user-images.githubusercontent.com/56001784/116013063-f9f97800-a5e2-11eb-97ac-a507f7f9b0c7.png)
