### PR TITLE
fix: padding around frame icons

### DIFF
--- a/src/components/DiagramFrame/DiagramFrame.tsx
+++ b/src/components/DiagramFrame/DiagramFrame.tsx
@@ -116,8 +116,8 @@ export const DiagramFrame: React.FC<DiagramFrameProps> = ({
 
   return (
     <Layout hasAside height="100%">
-      <Rail width="50px">
-        <SpaceVertical style={{alignItems: "center"}} alignItems="center" gap="xsmall">
+      <Rail width="50px" py="xxsmall" pr="xsmall">
+        <SpaceVertical style={{alignItems: "center"}} alignItems="center" gap="xsmall" ml="xxsmall">
           <IconButton
             icon={<AccountTree />}
             label="Settings"
@@ -126,8 +126,7 @@ export const DiagramFrame: React.FC<DiagramFrameProps> = ({
             onClick={() => {closePanels(); setShowSettings(!showSettings)}}
             toggle={showSettings}
             style={{color: showSettings && OVERRIDE_KEY, 
-              backgroundColor: showSettings && OVERRIDE_KEY_SUBTLE,
-              borderRadius: "10px"}}
+              backgroundColor: showSettings && OVERRIDE_KEY_SUBTLE}}
           />
           <IconButton
             icon={<Visibility />}
@@ -137,8 +136,7 @@ export const DiagramFrame: React.FC<DiagramFrameProps> = ({
             onClick={() => {closePanels(); setShowViewOptions(!showViewOptions)}}
             toggle={showViewOptions}
             style={{color: showViewOptions && OVERRIDE_KEY, 
-              backgroundColor: showViewOptions && OVERRIDE_KEY_SUBTLE,
-              borderRadius: "10px"}}
+              backgroundColor: showViewOptions && OVERRIDE_KEY_SUBTLE}}
           />
           <IconButton
             icon={<LiveHelp />}
@@ -150,7 +148,7 @@ export const DiagramFrame: React.FC<DiagramFrameProps> = ({
             toggle={showHelp}
             style={{color: showHelp && OVERRIDE_KEY, 
               backgroundColor: showHelp && OVERRIDE_KEY_SUBTLE,
-              borderRadius: "10px", position: "absolute", bottom: "0px"}}
+              position: "absolute", bottom: "5px"}}
           />
         </SpaceVertical>
       </Rail>

--- a/src/components/DiagramFrame/DiagramFrame.tsx
+++ b/src/components/DiagramFrame/DiagramFrame.tsx
@@ -93,6 +93,18 @@ export const DiagramFrame: React.FC<DiagramFrameProps> = ({
     }
   }
 
+  const settingsIconStyles = showSettings ?
+  {color: OVERRIDE_KEY, backgroundColor: OVERRIDE_KEY_SUBTLE} :
+  {}
+
+  const viewOptionsIconStyles = showViewOptions ?
+  {color: OVERRIDE_KEY, backgroundColor: OVERRIDE_KEY_SUBTLE} :
+  {}
+
+  const helpIconStyles = showHelp ?
+  {color: OVERRIDE_KEY, backgroundColor: OVERRIDE_KEY_SUBTLE} :
+  {}
+
   const modelDetails = prepareModelDropdown(unfilteredModels)
 
   let currentExplore: ILookmlModelExplore = modelDetail?.explores.filter((d: ILookmlModelExplore)=>{
@@ -125,8 +137,7 @@ export const DiagramFrame: React.FC<DiagramFrameProps> = ({
             size="large"
             onClick={() => {closePanels(); setShowSettings(!showSettings)}}
             toggle={showSettings}
-            style={{color: showSettings && OVERRIDE_KEY, 
-              backgroundColor: showSettings && OVERRIDE_KEY_SUBTLE}}
+            style={settingsIconStyles}
           />
           <IconButton
             icon={<Visibility />}
@@ -135,8 +146,7 @@ export const DiagramFrame: React.FC<DiagramFrameProps> = ({
             size="large"
             onClick={() => {closePanels(); setShowViewOptions(!showViewOptions)}}
             toggle={showViewOptions}
-            style={{color: showViewOptions && OVERRIDE_KEY, 
-              backgroundColor: showViewOptions && OVERRIDE_KEY_SUBTLE}}
+            style={viewOptionsIconStyles}
           />
           <IconButton
             icon={<LiveHelp />}
@@ -146,9 +156,11 @@ export const DiagramFrame: React.FC<DiagramFrameProps> = ({
             size="large"
             onClick={() => {closePanels(); setShowHelp(!showHelp)}}
             toggle={showHelp}
-            style={{color: showHelp && OVERRIDE_KEY, 
-              backgroundColor: showHelp && OVERRIDE_KEY_SUBTLE,
-              position: "absolute", bottom: "5px"}}
+            style={{
+              ...helpIconStyles,
+              position: "absolute",
+              bottom: "5px"
+            }}
           />
         </SpaceVertical>
       </Rail>

--- a/src/components/DiagramFrame/DiagramFrame.tsx
+++ b/src/components/DiagramFrame/DiagramFrame.tsx
@@ -93,16 +93,18 @@ export const DiagramFrame: React.FC<DiagramFrameProps> = ({
     }
   }
 
+  const iconStyleOverride = {color: OVERRIDE_KEY, backgroundColor: OVERRIDE_KEY_SUBTLE}
+
   const settingsIconStyles = showSettings ?
-  {color: OVERRIDE_KEY, backgroundColor: OVERRIDE_KEY_SUBTLE} :
+  iconStyleOverride :
   {}
 
   const viewOptionsIconStyles = showViewOptions ?
-  {color: OVERRIDE_KEY, backgroundColor: OVERRIDE_KEY_SUBTLE} :
+  iconStyleOverride :
   {}
 
   const helpIconStyles = showHelp ?
-  {color: OVERRIDE_KEY, backgroundColor: OVERRIDE_KEY_SUBTLE} :
+  iconStyleOverride :
   {}
 
   const modelDetails = prepareModelDropdown(unfilteredModels)

--- a/src/components/DiagramFrame/DiagramHeader.tsx
+++ b/src/components/DiagramFrame/DiagramHeader.tsx
@@ -42,6 +42,10 @@ export const DiagramHeader: React.FC<DiagramHeaderProps> = ({
   toggleExploreInfo,
  }) => {
 
+  const exploreInfoStyles = selectionInfo.lookmlElement === "explore" ?
+  {color: OVERRIDE_KEY, backgroundColor: OVERRIDE_KEY_SUBTLE} :
+  {}
+
   return (
     <DiagramHeaderWrapper
       py="xsmall"
@@ -57,8 +61,7 @@ export const DiagramHeader: React.FC<DiagramHeaderProps> = ({
             label="Explore Info" 
             icon={<Info />}
             onClick={toggleExploreInfo}
-            style={{color: selectionInfo.lookmlElement === "explore" && OVERRIDE_KEY, 
-              backgroundColor: selectionInfo.lookmlElement === "explore" && OVERRIDE_KEY_SUBTLE}}
+            style={exploreInfoStyles}
             size="large" 
           />
           <IconButton label="Reload Diagram" icon={<Refresh />} size="large" onClick={() => location.reload()} />

--- a/src/components/DiagramFrame/DiagramHeader.tsx
+++ b/src/components/DiagramFrame/DiagramHeader.tsx
@@ -58,8 +58,7 @@ export const DiagramHeader: React.FC<DiagramHeaderProps> = ({
             icon={<Info />}
             onClick={toggleExploreInfo}
             style={{color: selectionInfo.lookmlElement === "explore" && OVERRIDE_KEY, 
-              backgroundColor: selectionInfo.lookmlElement === "explore" && OVERRIDE_KEY_SUBTLE,
-              borderRadius: "25px"}}
+              backgroundColor: selectionInfo.lookmlElement === "explore" && OVERRIDE_KEY_SUBTLE}}
             size="large" 
           />
           <IconButton label="Reload Diagram" icon={<Refresh />} size="large" onClick={() => location.reload()} />


### PR DESCRIPTION
Spec:
![image](https://user-images.githubusercontent.com/56001784/116513903-1dd8ea00-a87f-11eb-8559-0dc80c72bc1a.png)

Now:
![image](https://user-images.githubusercontent.com/56001784/116513774-ed914b80-a87e-11eb-9c8d-7f9d6808eb2b.png)

I couldn't get the padding/margin exactly right for the rail, but this is fine for now

