### PR TITLE
fix: reload data not page

### DIFF
--- a/src/__tests__/components/DiagramHeader.spec.tsx
+++ b/src/__tests__/components/DiagramHeader.spec.tsx
@@ -31,6 +31,7 @@ import {
 import { DiagramHeader } from '../../components/DiagramFrame/DiagramHeader'
 import { shallow } from 'enzyme';
 import 'jest-styled-components'
+import { QueryClient, QueryClientProvider } from "react-query"
 
 // jest.mock("@looker/components", () => ({
 //   Heading: () => "Heading",
@@ -49,12 +50,15 @@ import 'jest-styled-components'
 // }))
 
 describe('<DiagramHeader />', () => {
+  const queryClient = new QueryClient()
   const basic = shallow(
-  <DiagramHeader
-    currentExplore={view_explore}
-    selectionInfo={{}}
-    toggleExploreInfo={undefined}
-  />);
+    <QueryClientProvider client={queryClient}>
+    <DiagramHeader
+      currentExplore={view_explore}
+      selectionInfo={{}}
+      toggleExploreInfo={undefined}
+    />
+    </QueryClientProvider>);
   it('should match the basic diagram header', () => {
     expect(basic.debug()).toMatchSnapshot();
   });

--- a/src/__tests__/components/__snapshots__/DiagramFrame.spec.tsx.snap
+++ b/src/__tests__/components/__snapshots__/DiagramFrame.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`<DiagramFrame /> default loading 1`] = `
   <Styled(Section)>
     <DiagramHeader currentExplore={[undefined]} selectionInfo={{...}} toggleExploreInfo={[Function: toggleExploreInfo]} />
     <Layout hasAside={true} height=\\"100%\\" id=\\"DiagramStage\\">
-      <DiagramCanvas modelDetail={{...}} unfilteredModels={{...}} pathModelName=\\"test\\" pathExploreName=\\"test_explore\\" currentDimensions={[undefined]} zoomFactor={0.5} reload={false} minimapUntoggled={true} minimapEnabled={false} setZoomFactor={[Function: bound _dispatchAction]} setViewPosition={[Function: bound _dispatchAction]} setReload={[Function: bound _dispatchAction]} setMinimapUntoggled={[Function: bound _dispatchAction]} setMinimapEnabled={[Function: bound _dispatchAction]} dimensions={[undefined]} explore={[undefined]} selectionInfo={{...}} setSelectionInfo={[Function: bound _dispatchAction]} hiddenToggle={true} displayFieldType=\\"all\\" viewVisible={{...}} viewPosition={{...}} />
+      <DiagramCanvas modelDetail={{...}} unfilteredModels={{...}} pathModelName=\\"test\\" pathExploreName=\\"test_explore\\" currentDimensions={[undefined]} zoomFactor={0.5} reload={false} minimapUntoggled={true} minimapEnabled={false} setZoomFactor={[Function: bound _dispatchAction]} setViewPosition={[Function: bound _dispatchAction]} setReload={[Function: bound _dispatchAction]} setMinimapUntoggled={[Function: bound _dispatchAction]} setMinimapEnabled={[Function: bound _dispatchAction]} explore={[undefined]} selectionInfo={{...}} setSelectionInfo={[Function: bound _dispatchAction]} hiddenToggle={true} displayFieldType=\\"all\\" viewVisible={{...}} viewPosition={{...}} />
     </Layout>
   </Styled(Section)>
 </Layout>"
@@ -23,16 +23,16 @@ exports[`<DiagramFrame /> should help section 1`] = `
 "<Layout hasAside={true} height=\\"100%\\">
   <Styled(Aside) width=\\"50px\\" py=\\"xxsmall\\" pr=\\"xsmall\\">
     <SpaceVertical style={{...}} alignItems=\\"center\\" gap=\\"xsmall\\" ml=\\"xxsmall\\">
-      <IconButton icon={{...}} label=\\"Settings\\" tooltipPlacement=\\"right\\" size=\\"large\\" onClick={[Function: toggleSettings]} toggle={true} style={{...}} />
+      <IconButton icon={{...}} label=\\"Settings\\" tooltipPlacement=\\"right\\" size=\\"large\\" onClick={[Function: toggleSettings]} toggle={false} style={{...}} />
       <IconButton icon={{...}} label=\\"View Options\\" tooltipPlacement=\\"right\\" size=\\"large\\" onClick={[Function: toggleViewOptions]} toggle={false} style={{...}} />
-      <IconButton icon={{...}} label=\\"Diagram Help\\" tooltipPlacement=\\"right\\" id=\\"diagram-help-btn\\" size=\\"large\\" onClick={[Function: toggleHelp]} toggle={false} style={{...}} />
+      <IconButton icon={{...}} label=\\"Diagram Help\\" tooltipPlacement=\\"right\\" id=\\"diagram-help-btn\\" size=\\"large\\" onClick={[Function: toggleHelp]} toggle={true} style={{...}} />
     </SpaceVertical>
   </Styled(Aside)>
-  <DiagramSettings modelPathName=\\"test\\" explorePathName=\\"test_explore\\" modelDetails={{...}} exploreList={[undefined]} modelDetail={{...}} selectionInfo={{...}} currentExplore={[undefined]} diagramExplore={[undefined]} setSelectionInfo={[Function: bound _dispatchAction]} setViewVisible={[Function: bound _dispatchAction]} setZoomFactor={[Function: bound _dispatchAction]} setViewPosition={[Function: bound _dispatchAction]} setMinimapUntoggled={[Function: bound _dispatchAction]} setMinimapEnabled={[Function: bound _dispatchAction]} />
+  <HelpPanel />
   <Styled(Section)>
     <DiagramHeader currentExplore={[undefined]} selectionInfo={{...}} toggleExploreInfo={[Function: toggleExploreInfo]} />
     <Layout hasAside={true} height=\\"100%\\" id=\\"DiagramStage\\">
-      <DiagramCanvas modelDetail={{...}} unfilteredModels={{...}} pathModelName=\\"test\\" pathExploreName=\\"test_explore\\" currentDimensions={[undefined]} zoomFactor={0.5} reload={false} minimapUntoggled={true} minimapEnabled={false} setZoomFactor={[Function: bound _dispatchAction]} setViewPosition={[Function: bound _dispatchAction]} setReload={[Function: bound _dispatchAction]} setMinimapUntoggled={[Function: bound _dispatchAction]} setMinimapEnabled={[Function: bound _dispatchAction]} dimensions={[undefined]} explore={[undefined]} selectionInfo={{...}} setSelectionInfo={[Function: bound _dispatchAction]} hiddenToggle={true} displayFieldType=\\"all\\" viewVisible={{...}} viewPosition={{...}} />
+      <DiagramCanvas modelDetail={{...}} unfilteredModels={{...}} pathModelName=\\"test\\" pathExploreName=\\"test_explore\\" currentDimensions={[undefined]} zoomFactor={0.5} reload={false} minimapUntoggled={true} minimapEnabled={false} setZoomFactor={[Function: bound _dispatchAction]} setViewPosition={[Function: bound _dispatchAction]} setReload={[Function: bound _dispatchAction]} setMinimapUntoggled={[Function: bound _dispatchAction]} setMinimapEnabled={[Function: bound _dispatchAction]} explore={[undefined]} selectionInfo={{...}} setSelectionInfo={[Function: bound _dispatchAction]} hiddenToggle={true} displayFieldType=\\"all\\" viewVisible={{...}} viewPosition={{...}} />
     </Layout>
   </Styled(Section)>
 </Layout>"
@@ -42,16 +42,15 @@ exports[`<DiagramFrame /> should settings section 1`] = `
 "<Layout hasAside={true} height=\\"100%\\">
   <Styled(Aside) width=\\"50px\\" py=\\"xxsmall\\" pr=\\"xsmall\\">
     <SpaceVertical style={{...}} alignItems=\\"center\\" gap=\\"xsmall\\" ml=\\"xxsmall\\">
-      <IconButton icon={{...}} label=\\"Settings\\" tooltipPlacement=\\"right\\" size=\\"large\\" onClick={[Function: toggleSettings]} toggle={true} style={{...}} />
+      <IconButton icon={{...}} label=\\"Settings\\" tooltipPlacement=\\"right\\" size=\\"large\\" onClick={[Function: toggleSettings]} toggle={false} style={{...}} />
       <IconButton icon={{...}} label=\\"View Options\\" tooltipPlacement=\\"right\\" size=\\"large\\" onClick={[Function: toggleViewOptions]} toggle={false} style={{...}} />
       <IconButton icon={{...}} label=\\"Diagram Help\\" tooltipPlacement=\\"right\\" id=\\"diagram-help-btn\\" size=\\"large\\" onClick={[Function: toggleHelp]} toggle={false} style={{...}} />
     </SpaceVertical>
   </Styled(Aside)>
-  <DiagramSettings modelPathName=\\"test\\" explorePathName=\\"test_explore\\" modelDetails={{...}} exploreList={[undefined]} modelDetail={{...}} selectionInfo={{...}} currentExplore={[undefined]} diagramExplore={[undefined]} setSelectionInfo={[Function: bound _dispatchAction]} setViewVisible={[Function: bound _dispatchAction]} setZoomFactor={[Function: bound _dispatchAction]} setViewPosition={[Function: bound _dispatchAction]} setMinimapUntoggled={[Function: bound _dispatchAction]} setMinimapEnabled={[Function: bound _dispatchAction]} />
   <Styled(Section)>
     <DiagramHeader currentExplore={[undefined]} selectionInfo={{...}} toggleExploreInfo={[Function: toggleExploreInfo]} />
     <Layout hasAside={true} height=\\"100%\\" id=\\"DiagramStage\\">
-      <DiagramCanvas modelDetail={{...}} unfilteredModels={{...}} pathModelName=\\"test\\" pathExploreName=\\"test_explore\\" currentDimensions={[undefined]} zoomFactor={0.5} reload={false} minimapUntoggled={true} minimapEnabled={false} setZoomFactor={[Function: bound _dispatchAction]} setViewPosition={[Function: bound _dispatchAction]} setReload={[Function: bound _dispatchAction]} setMinimapUntoggled={[Function: bound _dispatchAction]} setMinimapEnabled={[Function: bound _dispatchAction]} dimensions={[undefined]} explore={[undefined]} selectionInfo={{...}} setSelectionInfo={[Function: bound _dispatchAction]} hiddenToggle={true} displayFieldType=\\"all\\" viewVisible={{...}} viewPosition={{...}} />
+      <DiagramCanvas modelDetail={{...}} unfilteredModels={{...}} pathModelName=\\"test\\" pathExploreName=\\"test_explore\\" currentDimensions={[undefined]} zoomFactor={0.5} reload={false} minimapUntoggled={true} minimapEnabled={false} setZoomFactor={[Function: bound _dispatchAction]} setViewPosition={[Function: bound _dispatchAction]} setReload={[Function: bound _dispatchAction]} setMinimapUntoggled={[Function: bound _dispatchAction]} setMinimapEnabled={[Function: bound _dispatchAction]} explore={[undefined]} selectionInfo={{...}} setSelectionInfo={[Function: bound _dispatchAction]} hiddenToggle={true} displayFieldType=\\"all\\" viewVisible={{...}} viewPosition={{...}} />
     </Layout>
   </Styled(Section)>
 </Layout>"

--- a/src/__tests__/components/__snapshots__/DiagramHeader.spec.tsx.snap
+++ b/src/__tests__/components/__snapshots__/DiagramHeader.spec.tsx.snap
@@ -1,17 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<DiagramHeader /> should match the basic diagram header 1`] = `
-"<Styled(Header) py=\\"xsmall\\" px=\\"large\\" className=\\"has-explore\\">
-  <Space between={true}>
-    <Space gap=\\"xsmall\\">
-      <Heading as=\\"h1\\" px=\\"1rg\\">
-        Order Items
-      </Heading>
-    </Space>
-    <Space gap=\\"xsmall\\" justifyContent=\\"flex-end\\">
-      <IconButton label=\\"Explore Info\\" icon={{...}} onClick={[undefined]} style={{...}} size=\\"large\\" />
-      <IconButton label=\\"Reload Diagram\\" icon={{...}} size=\\"large\\" onClick={[Function: onClick]} />
-    </Space>
-  </Space>
-</Styled(Header)>"
+"<ContextProvider value={false}>
+  <ContextProvider value={{...}}>
+    <DiagramHeader currentExplore={{...}} selectionInfo={{...}} toggleExploreInfo={[undefined]} />
+  </ContextProvider>
+</ContextProvider>"
 `;

--- a/src/components/DiagramFrame/DiagramCanvas/DiagramCanvas.tsx
+++ b/src/components/DiagramFrame/DiagramCanvas/DiagramCanvas.tsx
@@ -36,6 +36,7 @@ import { DiagramToolbar } from "./DiagramToolbar"
 import {DiagramCanvasProps} from "./types"
 import {DiagramCanvasWrapper, Minimap, IntroText, ErrorText} from "./components/canvas_components"
 import { EmptyStateArt } from "./components/EmptyStateArt"
+import { DiagramMetadata } from "../../../utils/LookmlDiagrammer"
 
 const renderError = (fetchError: string) => {
   let errorText
@@ -96,7 +97,6 @@ export const DiagramCanvas: React.FC<DiagramCanvasProps> = ({
   modelDetail,
   pathModelName,
   pathExploreName,
-  currentDimensions,
   zoomFactor,
   reload,
   minimapUntoggled,
@@ -106,7 +106,7 @@ export const DiagramCanvas: React.FC<DiagramCanvasProps> = ({
   setReload,
   setMinimapUntoggled,
   setMinimapEnabled,
-  dimensions,
+  currentDimensions,
   explore,
   selectionInfo,
   setSelectionInfo,
@@ -116,6 +116,7 @@ export const DiagramCanvas: React.FC<DiagramCanvasProps> = ({
   viewPosition,
  }) => {
   const svgElement = document.querySelector(`svg#display-diagram-svg`)
+  const dimensions: DiagramMetadata = currentDimensions?.diagramDict
 
   if (modelDetail?.fetchError) {
     return renderError(modelDetail.fetchError)

--- a/src/components/DiagramFrame/DiagramCanvas/types.ts
+++ b/src/components/DiagramFrame/DiagramCanvas/types.ts
@@ -75,7 +75,6 @@ export interface DiagramCanvasProps {
   setReload: (r: boolean)=>void
   setMinimapUntoggled: (ut: boolean)=>void
   setMinimapEnabled: (e: boolean)=>void
-  dimensions: DiagramMetadata
   explore: ILookmlModelExplore
   selectionInfo: SelectionInfoPacket
   setSelectionInfo: (packet: SelectionInfoPacket) => void

--- a/src/components/DiagramFrame/DiagramFrame.tsx
+++ b/src/components/DiagramFrame/DiagramFrame.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { useCallback, memo, useEffect } from "react"
+import React, { useCallback } from "react"
 import {
   SpaceVertical,
   IconButton,

--- a/src/components/DiagramFrame/DiagramFrame.tsx
+++ b/src/components/DiagramFrame/DiagramFrame.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { useCallback, memo } from "react"
+import React, { useCallback, memo, useEffect } from "react"
 import {
   SpaceVertical,
   IconButton,
@@ -51,7 +51,7 @@ import {DiagramFrameProps} from "./types"
 import {Rail, Stage} from "./FrameHelpers"
 import {prepareModelDropdown, prepareExploreList} from "./utils"
 
-export const DiagramFrame: React.FC<DiagramFrameProps> = memo(({
+export const DiagramFrame: React.FC<DiagramFrameProps> = ({
   unfilteredModels,
   pathModelName,
   pathExploreName,
@@ -219,7 +219,6 @@ export const DiagramFrame: React.FC<DiagramFrameProps> = memo(({
           setReload={setReload}
           setMinimapUntoggled={setMinimapUntoggled}
           setMinimapEnabled={setMinimapEnabled}
-          dimensions={currentDiagramMetadata}
           explore={currentExplore}
           selectionInfo={selectionInfo}
           setSelectionInfo={setSelectionInfo}
@@ -239,4 +238,4 @@ export const DiagramFrame: React.FC<DiagramFrameProps> = memo(({
       </Stage>
       </Layout>
   )
-})
+}

--- a/src/components/DiagramFrame/DiagramHeader.tsx
+++ b/src/components/DiagramFrame/DiagramHeader.tsx
@@ -44,6 +44,7 @@ export const DiagramHeader: React.FC<DiagramHeaderProps> = ({
   toggleExploreInfo
  }) => {
   const queryClient = useQueryClient()
+  const reloadPage = () => queryClient.resetQueries()
 
   const exploreInfoStyles = selectionInfo.lookmlElement === "explore" ?
   {color: OVERRIDE_KEY, backgroundColor: OVERRIDE_KEY_SUBTLE} :
@@ -67,7 +68,7 @@ export const DiagramHeader: React.FC<DiagramHeaderProps> = ({
             style={exploreInfoStyles}
             size="large" 
           />
-          <IconButton label="Reload Diagram" icon={<Refresh />} size="large" onClick={() => queryClient.resetQueries()} />
+          <IconButton label="Reload Diagram" icon={<Refresh />} size="large" onClick={reloadPage} />
         </Space>
       </Space>
     </DiagramHeaderWrapper>

--- a/src/components/DiagramFrame/DiagramHeader.tsx
+++ b/src/components/DiagramFrame/DiagramHeader.tsx
@@ -30,6 +30,7 @@ import {
   Space,
   IconButton,
 } from "@looker/components"
+import { useQueryClient } from 'react-query'
 import { Info } from "@styled-icons/material-outlined/Info"
 import { Refresh } from "@styled-icons/material-outlined/Refresh"
 
@@ -40,8 +41,9 @@ import {DiagramHeaderWrapper} from "./FrameHelpers"
 export const DiagramHeader: React.FC<DiagramHeaderProps> = ({ 
   currentExplore,
   selectionInfo,
-  toggleExploreInfo,
+  toggleExploreInfo
  }) => {
+  const queryClient = useQueryClient()
 
   const exploreInfoStyles = selectionInfo.lookmlElement === "explore" ?
   {color: OVERRIDE_KEY, backgroundColor: OVERRIDE_KEY_SUBTLE} :
@@ -65,7 +67,7 @@ export const DiagramHeader: React.FC<DiagramHeaderProps> = ({
             style={exploreInfoStyles}
             size="large" 
           />
-          <IconButton label="Reload Diagram" icon={<Refresh />} size="large" onClick={() => location.reload()} />
+          <IconButton label="Reload Diagram" icon={<Refresh />} size="large" onClick={() => queryClient.resetQueries()} />
         </Space>
       </Space>
     </DiagramHeaderWrapper>

--- a/src/components/DiagramFrame/types.ts
+++ b/src/components/DiagramFrame/types.ts
@@ -44,5 +44,5 @@ export interface DiagramFrameProps {
 export interface DiagramHeaderProps {
   currentExplore: ILookmlModelExplore,
   selectionInfo: SelectionInfoPacket,
-  toggleExploreInfo: ()=>void
+  toggleExploreInfo: () => void,
 }

--- a/src/components/DiagramFrame/types.ts
+++ b/src/components/DiagramFrame/types.ts
@@ -44,5 +44,5 @@ export interface DiagramFrameProps {
 export interface DiagramHeaderProps {
   currentExplore: ILookmlModelExplore,
   selectionInfo: SelectionInfoPacket,
-  toggleExploreInfo: ()=>void,
+  toggleExploreInfo: ()=>void
 }

--- a/src/utils/fetchers.ts
+++ b/src/utils/fetchers.ts
@@ -28,6 +28,7 @@ import { useContext } from "react"
 import { useQuery, useMutation, useQueryClient } from 'react-query'
 import { ExtensionContext2 } from "@looker/extension-sdk-react"
 import { ILookmlModel, ILookmlModelExplore, IGitBranch } from "@looker/sdk/lib/4.0/models"
+import { DiagrammedModel, generateModelDiagrams } from "./LookmlDiagrammer"
 
 export interface DetailedModel {
   model: ILookmlModel
@@ -100,11 +101,28 @@ export function useLookmlModelExplores(model: ILookmlModel) {
   {
     enabled: !!model,
     retry: false,
-    ...defaultQueryOptions
+    ...defaultQueryOptions,
+    initialData: undefined
   })
   const explores = data
   const modelExploreError = error && "notFound"
   return {explores, modelExploreError}
+}
+
+/**
+ * gets the model diagrams from the detailed model
+ * @returns diagrammable model metadata
+ */
+ export function useModelDiagrams(modelDetail: DetailedModel, hiddenToggle: boolean, displayFieldType: string): DiagrammedModel[] {
+  const { isLoading, error, data } = useQuery(JSON.stringify(modelDetail),
+    () => generateModelDiagrams(modelDetail, hiddenToggle, displayFieldType),
+    {
+      ...defaultQueryOptions,
+      initialData: undefined
+    }
+  )
+  const dimensions = data
+  return dimensions
 }
 
 /**
@@ -161,8 +179,7 @@ export function useUpdateGitBranches(projectId: string) {
     })),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries()
-        location.reload()
+        queryClient.resetQueries()
       }
     }
   )

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -23,10 +23,9 @@
  SOFTWARE.
 
  */
-
 import { useRouteMatch } from "react-router-dom"
-import { useAllModels, useLookmlModelExplores, useAvailableGitBranches, useCurrentGitBranch } from "./fetchers"
-import { generateModelDiagrams, DiagrammedModel } from "./LookmlDiagrammer"
+import { useAllModels, useLookmlModelExplores, useAvailableGitBranches, useCurrentGitBranch, DetailedModel, useModelDiagrams } from "./fetchers"
+import { DiagrammedModel } from "./LookmlDiagrammer"
 
 export function internalExploreURL({
   model,
@@ -104,18 +103,18 @@ export function useSelectExplore(hiddenToggle: boolean, displayFieldType: string
   const {gitBranch, branchError} = useCurrentGitBranch(model?.project_name)
   const {gitBranches, branchesError} = useAvailableGitBranches(model?.project_name)
   const fetchError = modelExploreError || branchError || branchesError
-  const modelDetail = {
+  const modelDetail: DetailedModel = {
     model,
     explores,
     gitBranch,
     gitBranches,
     fetchError
   }
-  let dimensions: DiagrammedModel[] = generateModelDiagrams(modelDetail, hiddenToggle, displayFieldType)
+  const dimensions = useModelDiagrams(modelDetail, hiddenToggle, displayFieldType)
   return {
     unfilteredModels,
-    modelDetail, 
-    dimensions, 
+    modelDetail,
+    dimensions,
   }
 }
 


### PR DESCRIPTION
I had to add the diagrammable metadata to the react query cache and use `resetQueries` instead of invalidate cache. 