### PR TITLE
fix: changing from c-hive/gha-yarn-cache@v1 to actions/setup-node@v4

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,18 +4,21 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: c-hive/gha-yarn-cache@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: 'yarn'
       - run: yarn
       - run: yarn lint
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: c-hive/gha-yarn-cache@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12.x
+          node-version: 18.x
+          cache: 'yarn'
       - run: yarn install &> /dev/null
       - run: yarn test
     env:
@@ -23,11 +26,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12.x
-      - uses: c-hive/gha-yarn-cache@v1
+          node-version: 18.x
+          cache: 'yarn'
       - run: yarn
       - run: yarn build:ci:clean
       - run: yarn build:ci


### PR DESCRIPTION
### Changes

- Change from c-hive/gha-yarn-cache@v1 to actions/setup-node@v4 in the pull_request.yml file.

**Note:** Since the c-hive/gha-yarn-cache@v1 is deprecated, the [official documentation](https://github.com/marketplace/actions/yarn-install-cache) mentions to use the actions/setup-node@v4